### PR TITLE
Removes unreachable else-if clauses.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/jsonorg/JSONArraySerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsonorg/JSONArraySerializer.java
@@ -74,8 +74,6 @@ public class JSONArraySerializer extends JSONBaseSerializer<JSONArray>
                 JSONObjectSerializer.instance.serialize((JSONObject) ob, jgen, provider);
             } else if (JSONArray.class.isAssignableFrom(cls)) { // sub-class
                 serialize((JSONArray) ob, jgen, provider);
-            } else if (JSONArray.class.isAssignableFrom(cls)) { // sub-class
-                JSONArraySerializer.instance.serialize((JSONArray) ob, jgen, provider);
             } else {
                 provider.defaultSerializeValue(ob, jgen);
             }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsonorg/JSONObjectSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsonorg/JSONObjectSerializer.java
@@ -75,8 +75,6 @@ public class JSONObjectSerializer extends JSONBaseSerializer<JSONObject>
                 jgen.writeBoolean(((Boolean) ob).booleanValue());
             } else  if (cls == Double.class) {
                 jgen.writeNumber(((Double) ob).doubleValue());
-            } else if (cls == JSONArray.class) {
-                JSONArraySerializer.instance.serialize((JSONArray) ob, jgen, provider);
             } else if (JSONObject.class.isAssignableFrom(cls)) { // sub-class
                 serialize((JSONObject) ob, jgen, provider);
             } else if (JSONArray.class.isAssignableFrom(cls)) { // sub-class


### PR DESCRIPTION
Removes unreachable statements due to else-if statements with equivalent boolean expression present in prior condition:

In ```JSONArraySerializer``` condition in line 75 is equal to the one in line 77. For ```JSONObjectSerializer```  compare lines 66 to 67 with lines 78 to 79